### PR TITLE
Improve Electron startup

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,30 +35,24 @@ This section details the setup of a basic developmentment environment.
 > yarn install
 ```
 
----
+**Start in Development**
 
-**Launch React App**
-
-```console
-> yarn start
-```
-
----
-
-**Launch Electron App**
+The launcher integrates React with Electron. Use the following command to run the application in development mode and automatically open the desktop window:
 
 ```console
-> yarn run electron:watch
+> npm start
 ```
+
+If you only want to run the React development server, execute `npm run react:start`.
 
 ---
 
 **Build Installers**
 
-To build for your current platform.
+To create a production build for your platform run:
 
 ```console
-> yarn run build
+> npm run electron:build
 ```
 
 ---

--- a/package.json
+++ b/package.json
@@ -34,13 +34,14 @@
     "web-vitals": "^2.1.4"
   },
   "scripts": {
-    "start": "react-scripts start",
+    "react:start": "react-scripts start",
+    "start": "npm run electron:dev",
     "build": "react-scripts build",
     "test": "react-scripts test",
     "postinstall": "electron-builder install-app-deps",
     "electron:start": "wait-on http://localhost:3000 && electron .",
     "electron:watch": "nodemon --watch \"electron/**/*\" -e ts --exec \"tsc -p electron && electron .\" ",
-    "electron:dev": "concurrently \"cross-env BROWSER=none yarn start\" \"wait-on http://localhost:3000 && tsc -p electron && electron .\"",
+    "electron:dev": "concurrently \"cross-env BROWSER=none npm run react:start\" \"wait-on http://localhost:3000 && tsc -p electron && electron .\"",
     "electron:build": "yarn build && tsc -p electron && electron-builder",
     "eject": "react-scripts eject"
     


### PR DESCRIPTION
## Summary
- run Electron in development by default
- document how to start the launcher and build installers

## Testing
- `npm test -- --watchAll=false --passWithNoTests`

------
https://chatgpt.com/codex/tasks/task_e_688124556d5c8325a455c9e278d1a614