### PR TITLE
Fix launcher loading

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 <p align="center"><img src="./public/assets/logo.png" width="150px" height="150px" alt="logo"></p>
 
-<h1 align="center">React MCLauncher</h1>
+<h1 align="center">TECNILAND Nexus</h1>
 
 Custom launcher for modded minecraft written in Electron with React.
 
@@ -37,7 +37,7 @@ This section details the setup of a basic developmentment environment.
 
 **Start in Development**
 
-The launcher integrates React with Electron. Use the following command to run the application in development mode and automatically open the desktop window:
+The launcher integrates React with Electron. Use the following command to build the React frontend and launch the desktop window:
 
 ```console
 > npm start

--- a/electron/main.ts
+++ b/electron/main.ts
@@ -13,7 +13,7 @@ autoUpdater.logger = log;
 import type * as ConfigManagerTypes from "./utils/configmanager";
 //Global module
 const configManager: typeof ConfigManagerTypes = require("./utils/configmanager");
-const LAUNCHER_NAME = "ReactMCLauncher";
+const LAUNCHER_NAME = "TECNILAND Nexus";
 
 let win: BrowserWindow | null = null;
 
@@ -28,11 +28,8 @@ function createWindow() {
     title: LAUNCHER_NAME,
     icon: path.join(__dirname, "..", "..", "public", "assets", "logo.png"),
   });
-  if (app.isPackaged) {
-    win.loadURL(`file://${__dirname}/../index.html`);
-  } else {
-    win.loadURL("http://localhost:3000");
-  }
+  const indexPath = `file://${path.join(__dirname, "../index.html")}`;
+  win.loadURL(indexPath);
 }
 
 app.whenReady().then(() => {

--- a/electron/utils/configmanager.ts
+++ b/electron/utils/configmanager.ts
@@ -10,7 +10,7 @@ import type { Profile } from "./authmanager";
 // Launcher global constants
 export const LAUNCHER_CONFIG =
   "https://dd06-dev.fr/dl/launchers/react-mc-launcher/launcher_config.json";
-export const LAUNCHER_NAME = "ReactMCLauncher";
+export const LAUNCHER_NAME = "TECNILAND Nexus";
 export const MC_VERSION = "1.12.2";
 export const FORGE_VERSION = "14.23.5.2855";
 export const JRE_WINDOWS = "https://dd06-dev.fr/dl/jre/jre-windows.zip";

--- a/package.json
+++ b/package.json
@@ -39,9 +39,9 @@
     "build": "react-scripts build",
     "test": "react-scripts test",
     "postinstall": "electron-builder install-app-deps",
-    "electron:start": "wait-on http://localhost:3000 && electron .",
+    "electron:start": "electron .",
     "electron:watch": "nodemon --watch \"electron/**/*\" -e ts --exec \"tsc -p electron && electron .\" ",
-    "electron:dev": "concurrently \"cross-env BROWSER=none npm run react:start\" \"wait-on http://localhost:3000 && tsc -p electron && electron .\"",
+    "electron:dev": "npm run build && tsc -p electron && electron .",
     "electron:build": "yarn build && tsc -p electron && electron-builder",
     "eject": "react-scripts eject"
     


### PR DESCRIPTION
## Summary
- rename project to TECNILAND Nexus
- always load Electron window from the build output
- build frontend before starting Electron

## Testing
- `npm run build`
- `npx tsc -p electron`


------
https://chatgpt.com/codex/tasks/task_e_68812725be208325885f458723f71b08