### PR TITLE
Limpieza general y comentarios en español

### DIFF
--- a/electron/auth.ts
+++ b/electron/auth.ts
@@ -7,8 +7,14 @@ import type * as ConfigManagerTypes from "./utils/configmanager";
 //Global module
 const configManager: typeof ConfigManagerTypes = require("./utils/configmanager");
 
+// Encargado de gestionar todo el flujo de autenticación (Microsoft y offline)
 const logger = new Logger("[AuthManager]");
 
+/**
+ * Inicializa todos los manejadores IPC relacionados con la autenticación de
+ * usuarios. Permite iniciar sesión mediante Microsoft o modo offline y
+ * gestionar la sesión automática.
+ */
 export function initAuth() {
   ipc.on("microsoft-login", (event, autoAuth: boolean) => {
     configManager.setAutoAuthEnabled(autoAuth);

--- a/electron/game.ts
+++ b/electron/game.ts
@@ -10,6 +10,9 @@ import crypto from "crypto";
 import Logger from "./utils/logger";
 import ChildProcess from "child_process";
 
+// Módulo encargado de actualizar y lanzar el juego utilizando
+// minecraft-launcher-core y gestionando la descarga de dependencias.
+
 import type * as ConfigManagerTypes from "./utils/configmanager";
 //Global module
 const configManager: typeof ConfigManagerTypes = require("./utils/configmanager");
@@ -21,6 +24,10 @@ const javaLogger = new Logger("[JavaLogger]");
 
 let jre = "default";
 
+/**
+ * Registra el manejador IPC para iniciar la secuencia de descarga y
+ * posterior lanzamiento del juego.
+ */
 export function initGame() {
   ipc.on("play", () => play());
 }

--- a/electron/main.ts
+++ b/electron/main.ts
@@ -7,6 +7,7 @@ import { autoUpdater } from "electron-updater";
 import { initAuth } from "./auth";
 import { initGame } from "./game";
 import log from "electron-log";
+// Redirigimos todos los logs a electron-log para tener trazas persistentes.
 console.log = log.log;
 autoUpdater.logger = log;
 
@@ -17,6 +18,7 @@ const LAUNCHER_NAME = "TECNILAND Nexus";
 
 let win: BrowserWindow | null = null;
 
+// Crea la ventana principal del launcher y carga la aplicación React
 function createWindow() {
   win = new BrowserWindow({
     width: 1280,
@@ -60,6 +62,8 @@ app.whenReady().then(() => {
 ipc.on("install-updates", () => {
   autoUpdater.quitAndInstall();
 });
+// Comprueba si existen actualizaciones del launcher y gestiona el proceso
+// de descarga e instalación utilizando electron-updater.
 ipc.on("check-auto-update", () => {
   if (isDev) {
     autoUpdater.updateConfigPath = path.join(__dirname, "dev-app-update.yml");

--- a/electron/mainIPC.ts
+++ b/electron/mainIPC.ts
@@ -15,15 +15,18 @@ const logger = new Logger("[Launcher]");
 function initMainIPC() {
   //Async utils
   ipc.on("open-link", (event, args) => shell.openExternal(args));
-  // Launch game through a custom batch file
+  // Ejecuta un script local para lanzar el juego. La ruta se obtiene de la
+  // variable de entorno LOCAL_GAME_SCRIPT para permitir configuraciones
+  // personalizadas en cada máquina.
   ipc.on("launch-local-game", () => {
+    const scriptPath = process.env.LOCAL_GAME_SCRIPT;
+    if (!scriptPath) {
+      logger.error("LOCAL_GAME_SCRIPT no está definida");
+      return;
+    }
     try {
       const { spawn } = require("child_process");
-      const bat = spawn(
-        "C:\\Users\\Keash\\Documents\\TECNILAND\\launch.bat",
-        [],
-        { shell: true }
-      );
+      const bat = spawn(scriptPath, [], { shell: true });
       bat.stdout.on("data", (data: Buffer) => console.log(data.toString()));
       bat.stderr.on("data", (data: Buffer) => console.error(data.toString()));
       bat.on("error", (err: Error) => console.error("Error launching:", err));

--- a/electron/tsconfig.json
+++ b/electron/tsconfig.json
@@ -1,21 +1,19 @@
 {
-    "compilerOptions": {
-      "target": "ES2015",
-      "module": "commonjs",
-      "moduleResolution": "node",
-      "sourceMap": true,
-      "strict": true,
-      "strictNullChecks": true,
-      "outDir": "../build",
-      "rootDir": "../",
-      "noEmitOnError": true,
-      "esModuleInterop": true,
-      "typeRoots": [
-        "node_modules/@types"
-      ],
-      "declaration": true,
-      "skipLibCheck": true,
-
-    },
-    
+  "compilerOptions": {
+    "target": "ES2015",
+    "module": "commonjs",
+    "moduleResolution": "node",
+    "sourceMap": true,
+    "strict": true,
+    "strictNullChecks": true,
+    "outDir": "../build",
+    "rootDir": "../",
+    "noEmitOnError": true,
+    "esModuleInterop": true,
+    "typeRoots": [
+      "node_modules/@types"
+    ],
+    "declaration": true,
+    "skipLibCheck": true
+  }
 }

--- a/src/screens/MainScreen.tsx
+++ b/src/screens/MainScreen.tsx
@@ -1,17 +1,17 @@
 import React from 'react';
-// Main launcher entry screen
+// Pantalla principal de inicio del launcher
 import 'styles/MainScreen.css';
 import { launchLocalGame } from 'utils/launcher';
 
 /**
- * MainScreen renders the first view of the launcher. It contains the
- * application title, a short description and a play button. The play
- * button triggers the launch of the local Minecraft installation via
- * IPC to the Electron main process.
+ * Componente que muestra la vista inicial del launcher. Aquí se visualiza
+ * el título de la aplicación y un botón para ejecutar el modpack local.
+ * Al pulsar "JUGAR" se envía el evento correspondiente al proceso de
+ * Electron para que se ejecute el script configurado.
  */
 const MainScreen: React.FC = () => {
   const handlePlay = () => {
-    // Delegate to the launcher utility
+    // Delegamos la acción al helper encargado de comunicarse con Electron
     launchLocalGame();
   };
 

--- a/src/screens/TecnilandScreen.tsx
+++ b/src/screens/TecnilandScreen.tsx
@@ -1,4 +1,5 @@
-import React, { useEffect, useState } from 'react'; // Aquí irá tu CSS personalizado
+import React, { useEffect, useState } from 'react';
+// Componente experimental para nuevas funcionalidades del launcher.
 
 const TecnilandScreen = () => {
   const [currentPage, setCurrentPage] = useState<'splash' | 'login' | 'main'>('splash');

--- a/src/utils/launcher.ts
+++ b/src/utils/launcher.ts
@@ -1,7 +1,9 @@
 /**
- * Utilities related to launching the local Minecraft instance.
+ * Funciones de utilidad relacionadas con el lanzamiento del juego
+ * Minecraft de forma local.
  */
 export function launchLocalGame() {
-  // Delegate the launch to the Electron main process
+  // Enviamos un mensaje al proceso principal de Electron para que ejecute
+  // el script configurado y así iniciar el juego.
   window.ipc.send('launch-local-game');
 }

--- a/src/utils/withRouter.tsx
+++ b/src/utils/withRouter.tsx
@@ -1,6 +1,11 @@
 import { ComponentType } from "react";
 import { useNavigate } from "react-router-dom";
 
+/**
+ * Componente de orden superior que inyecta la función `navigate` de React
+ * Router para poder utilizarla en componentes de clase.
+ */
+
 export const withRouter = <P extends object>(Component: ComponentType<P>) => {
   const Wrapper = (props: P) => {
     const navigate = useNavigate();


### PR DESCRIPTION
## Resumen
- agregar comentarios en español en utilidades y pantallas
- permitir definir ruta de script local mediante `LOCAL_GAME_SCRIPT`
- limpiar `tsconfig` de Electron
- pequeñas anotaciones en main y auth para mayor claridad

## Testing
- `npx tsc -p electron/tsconfig.json --noEmit`
- `npx tsc --noEmit`


------
https://chatgpt.com/codex/tasks/task_e_68812c9024f08325a2293f45a2b887b3