### PR TITLE
Add offline login workflow

### DIFF
--- a/src/index.tsx
+++ b/src/index.tsx
@@ -11,6 +11,9 @@ import Settings from "screens/Settings";
 import TecnilandScreen from "screens/TecnilandScreen";
 import LauncherUpdater from "screens/LauncherUpdater";
 import MainScreen from "screens/MainScreen";
+import Init from "screens/offline/Init";
+import OfflineLogin from "screens/offline/OfflineLogin";
+import OfflineLauncher from "screens/offline/OfflineLauncher";
 // Global application styles
 import "styles/index.css";
 // Font Awesome icons
@@ -36,8 +39,12 @@ ReactDOM.render(
       <Frame />
       <BrowserRouter>
         <Routes>
-          {/* Landing page of the launcher */}
-          <Route path="/" element={<MainScreen />} />
+          {/* Flujo de inicio offline */}
+          <Route path="/" element={<Init />} />
+          <Route path="/login" element={<OfflineLogin />} />
+          <Route path="/home" element={<OfflineLauncher />} />
+
+          {/* Rutas originales */}
           <Route path="/update" element={<LauncherUpdater />} />
           <Route path="/auth" element={<Auth />} />
           <Route path="/launcher" element={<Launcher />} />

--- a/src/screens/offline/Init.tsx
+++ b/src/screens/offline/Init.tsx
@@ -1,0 +1,23 @@
+import { useEffect } from 'react';
+import { useNavigate } from 'react-router-dom';
+
+/**
+ * Componente inicial que redirige al login o al launcher
+ * dependiendo de si existe un usuario almacenado.
+ */
+const Init: React.FC = () => {
+  const navigate = useNavigate();
+
+  useEffect(() => {
+    const savedUser = localStorage.getItem('offlineUser');
+    if (savedUser) {
+      navigate('/home');
+    } else {
+      navigate('/login');
+    }
+  }, [navigate]);
+
+  return null;
+};
+
+export default Init;

--- a/src/screens/offline/OfflineLauncher.tsx
+++ b/src/screens/offline/OfflineLauncher.tsx
@@ -1,0 +1,41 @@
+import React, { useState } from 'react';
+import 'styles/OfflineLauncher.css';
+
+/**
+ * Pantalla principal del launcher tras el inicio de sesión offline.
+ */
+const versions = ['1.20.1', '1.19.4', '1.18.2', '1.16.5'];
+
+const OfflineLauncher: React.FC = () => {
+  const savedUser = localStorage.getItem('offlineUser') || '';
+  const [version, setVersion] = useState('1.20.1');
+
+  const handlePlay = () => {
+    window.ipc.send('play-version', { username: savedUser, version });
+  };
+
+  return (
+    <div className="offline-launcher-container">
+      <h2>Bienvenido, {savedUser}</h2>
+      <div className="version-selector">
+        <label>Versión:</label>
+        <select value={version} onChange={(e) => setVersion(e.target.value)}>
+          {versions.map((v) => (
+            <option key={v} value={v}>
+              {v}
+            </option>
+          ))}
+        </select>
+      </div>
+      <button className="play-button" onClick={handlePlay}>
+        JUGAR
+      </button>
+      <div className="news-box">
+        <h3>Novedades</h3>
+        <p>Próximamente más actualizaciones del launcher.</p>
+      </div>
+    </div>
+  );
+};
+
+export default OfflineLauncher;

--- a/src/screens/offline/OfflineLogin.tsx
+++ b/src/screens/offline/OfflineLogin.tsx
@@ -1,0 +1,34 @@
+import React, { useState } from 'react';
+import { useNavigate } from 'react-router-dom';
+import 'styles/OfflineLogin.css';
+
+/**
+ * Pantalla de inicio de sesión offline. Solicita un nombre de usuario
+ * y lo guarda localmente para futuras sesiones.
+ */
+const OfflineLogin: React.FC = () => {
+  const [username, setUsername] = useState('');
+  const navigate = useNavigate();
+
+  const handleLogin = () => {
+    if (username.trim()) {
+      localStorage.setItem('offlineUser', username.trim());
+      navigate('/home');
+    }
+  };
+
+  return (
+    <div className="offline-login-container">
+      <h1>TECNILAND Nexus</h1>
+      <input
+        type="text"
+        placeholder="Nombre o alias"
+        value={username}
+        onChange={(e) => setUsername(e.target.value)}
+      />
+      <button onClick={handleLogin}>Iniciar sesión</button>
+    </div>
+  );
+};
+
+export default OfflineLogin;

--- a/src/styles/OfflineLauncher.css
+++ b/src/styles/OfflineLauncher.css
@@ -1,0 +1,41 @@
+.offline-launcher-container {
+  height: 100vh;
+  background-image: url('../../public/assets/background.png');
+  background-size: cover;
+  display: flex;
+  flex-direction: column;
+  justify-content: center;
+  align-items: center;
+  color: white;
+  font-family: 'Open Sans', sans-serif;
+}
+
+.version-selector {
+  margin: 20px 0;
+}
+
+.play-button {
+  padding: 15px 30px;
+  font-size: 1.5rem;
+  background-color: #00c853;
+  border: none;
+  border-radius: 8px;
+  color: #fff;
+  cursor: pointer;
+  box-shadow: 0 0 10px rgba(0, 0, 0, 0.5);
+  transition: background-color 0.3s, transform 0.3s;
+}
+
+.play-button:hover {
+  background-color: #03a64e;
+  transform: scale(1.05);
+}
+
+.news-box {
+  margin-top: 40px;
+  background: rgba(0, 0, 0, 0.4);
+  padding: 20px;
+  border-radius: 10px;
+  text-align: center;
+  width: 60%;
+}

--- a/src/styles/OfflineLogin.css
+++ b/src/styles/OfflineLogin.css
@@ -1,0 +1,31 @@
+.offline-login-container {
+  height: 100vh;
+  display: flex;
+  flex-direction: column;
+  justify-content: center;
+  align-items: center;
+  background-image: url('../../public/assets/background.png');
+  background-size: cover;
+  color: white;
+  font-family: 'Open Sans', sans-serif;
+}
+
+.offline-login-container input {
+  margin-top: 20px;
+  padding: 10px;
+  width: 250px;
+  border-radius: 5px;
+  border: none;
+  text-align: center;
+}
+
+.offline-login-container button {
+  margin-top: 20px;
+  padding: 10px 20px;
+  font-size: 1rem;
+  border: none;
+  border-radius: 5px;
+  cursor: pointer;
+  background-color: #56b5fc;
+  color: white;
+}


### PR DESCRIPTION
## Summary
- create offline login screen and simple launcher interface
- add navigation controller for offline workflow
- implement vanilla Minecraft launch via IPC

## Testing
- `npm test --silent`

------
https://chatgpt.com/codex/tasks/task_e_6881375a67788325933bd7eeecc52f99