### PR TITLE
Add mandatory Java path selection

### DIFF
--- a/electron/game.ts
+++ b/electron/game.ts
@@ -25,8 +25,8 @@ const javaLogger = new Logger("[JavaLogger]");
 let jre = "default";
 
 export function isJavaAvailable(): boolean {
-  const javaExec = configManager.resolveJavaPath();
-  if (!javaExec) return false;
+  const javaExec = configManager.getJavaExecutable();
+  if (!javaExec || !fs.existsSync(javaExec)) return false;
   try {
     const res = ChildProcess.spawnSync(javaExec, ["-version"]);
     if (res.error) return false;
@@ -96,7 +96,7 @@ async function updateAndLaunch() {
               "bin",
               process.platform === "win32" ? "java.exe" : "java"
             )
-          : configManager.resolveJavaPath() || undefined;
+          : configManager.getJavaExecutable() || undefined;
       const launcher = new Client();
       const opts = {
         clientPackage: undefined,
@@ -209,8 +209,8 @@ function checkJavaInstallation() {
       });
     }
 
-    const execCmd = configManager.resolveJavaPath();
-    if (!execCmd) {
+    const execCmd = configManager.getJavaExecutable();
+    if (!execCmd || !fs.existsSync(execCmd)) {
       javaLogger.log("No java installation found!");
       return reject();
     }

--- a/electron/mainIPC.ts
+++ b/electron/mainIPC.ts
@@ -76,18 +76,24 @@ function initMainIPC() {
         },
       ],
     });
-    if (!result.canceled && result.filePaths.length > 0) {
-      configManager.setJavaExecutable(result.filePaths[0]);
-      configManager.saveConfig();
-      event.sender.send("java-path-selected", result.filePaths[0]);
-    }
-  });
+      if (!result.canceled && result.filePaths.length > 0) {
+        if (configManager.setJavaExecutable(result.filePaths[0])) {
+          configManager.saveConfig();
+          event.sender.send("java-path-selected", result.filePaths[0]);
+        } else {
+          event.sender.send("java-path-invalid");
+        }
+      }
+    });
   ipc.on("set-java-path", (event, args) => {
-    configManager.setJavaExecutable(args);
-    configManager.saveConfig();
+    const res = configManager.setJavaExecutable(args);
+    if (res) {
+      configManager.saveConfig();
+    }
+    event.returnValue = res;
   });
   ipc.on("get-java-path", (event) => {
-    event.returnValue = configManager.resolveJavaPath() || "";
+    event.returnValue = configManager.getJavaExecutable() || "";
   });
   ipc.on("is-java-valid", (event) => {
     event.returnValue = isJavaAvailable();

--- a/electron/utils/configmanager.ts
+++ b/electron/utils/configmanager.ts
@@ -403,10 +403,12 @@ export function getJavaExecutable(def: boolean = false) {
   return !def ? config?.settings.java.path : "";
 }
 
-export function setJavaExecutable(javaPath: string) {
-  if (config) {
+export function setJavaExecutable(javaPath: string): boolean {
+  if (config && javaPath && fs.existsSync(javaPath)) {
     config.settings.java.path = javaPath;
+    return true;
   }
+  return false;
 }
 
 export function autoDetectJavaPath(): string | null {
@@ -449,14 +451,6 @@ export function resolveJavaPath(): string | null {
   if (configured && fs.existsSync(configured)) {
     return configured;
   }
-
-  const detected = autoDetectJavaPath();
-  if (detected && config) {
-    config.settings.java.path = detected;
-    saveConfig();
-    return detected;
-  }
-
   return null;
 }
 

--- a/src/langs/en.json
+++ b/src/langs/en.json
@@ -79,6 +79,6 @@
     "java-path": "Java path",
     "select-java": "Select Java",
     "java-path-not-set": "Not set",
-    "java-missing": "Java executable not found. Please select the path"
+    "java-missing": "Java path not configured. Go to settings to set it"
   }
 }

--- a/src/langs/fr.json
+++ b/src/langs/fr.json
@@ -79,6 +79,6 @@
     "java-path": "Chemin Java",
     "select-java": "Sélectionner Java",
     "java-path-not-set": "Non défini",
-    "java-missing": "Java introuvable. Veuillez sélectionner le chemin"
+    "java-missing": "Chemin Java non configuré. Rendez-vous dans les paramètres pour le définir"
   }
 }

--- a/src/screens/Launcher.tsx
+++ b/src/screens/Launcher.tsx
@@ -90,6 +90,18 @@ class Launcher extends Component<Props & WithTranslation, State> {
       return;
     }
 
+    const javaPath = window.ipc.sendSync("get-java-path");
+    if (!javaPath) {
+      Swal.fire({
+        title: t("error"),
+        text: t("settings.java-missing"),
+        icon: "error",
+        confirmButtonColor: "#54c2f0",
+        background: "#333",
+      });
+      return;
+    }
+
     const javaValid = window.ipc.sendSync("is-java-valid");
     if (!javaValid) {
       Swal.fire({

--- a/src/screens/Settings.tsx
+++ b/src/screens/Settings.tsx
@@ -168,7 +168,25 @@ class Settings extends Component<Props & WithTranslation, State> {
             <Button onClick={() => window.ipc.send("open-game-dir")}>
               {t("settings.open-game-dir")}
             </Button>
-            <h4>{t("settings.java-path")}: {javaPath || t("settings.java-path-not-set")}</h4>
+            <h4>{t("settings.java-path")}</h4>
+            <input
+              type="text"
+              className="java-path-input"
+              value={javaPath}
+              onChange={(e) => this.setState({ javaPath: e.target.value })}
+              onBlur={() => {
+                const valid = window.ipc.sendSync("set-java-path", this.state.javaPath);
+                if (!valid) {
+                  Swal.fire({
+                    title: t("error"),
+                    text: t("settings.java-missing"),
+                    icon: "error",
+                    confirmButtonColor: "#54c2f0",
+                    background: "#333",
+                  });
+                }
+              }}
+            />
             <Button onClick={this.handleSelectJava}>{t("settings.select-java")}</Button>
           </section>
           <section className="launcher">

--- a/src/styles/Settings.css
+++ b/src/styles/Settings.css
@@ -69,6 +69,16 @@
     text-transform: none;
 }
 
+.java-path-input {
+    width: 80%;
+    margin-left: 35px;
+    margin-top: 10px;
+    padding: 5px;
+    background: rgba(255, 255, 255, 0.1);
+    border: none;
+    color: white;
+}
+
 
 .settings-content .switch-label {
     color: white;


### PR DESCRIPTION
## Summary
- store custom Java executable path in config only when valid
- ensure Java path existence checks before game launch
- allow manual Java path entry in settings
- surface Java path errors on play
- update translations for new message

## Testing
- `npm test`
- `npm run build`
- `npx tsc -p electron`


------
https://chatgpt.com/codex/tasks/task_e_68815515a8f4832582f1dd3453d1b34c