### PR TITLE
Fix local script launch error handling

### DIFF
--- a/src/screens/MainScreen.tsx
+++ b/src/screens/MainScreen.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { useEffect } from 'react';
 // Pantalla principal de inicio del launcher
 import 'styles/MainScreen.css';
 import { launchLocalGame } from 'utils/launcher';
@@ -14,6 +14,17 @@ const MainScreen: React.FC = () => {
     // Delegamos la acción al helper encargado de comunicarse con Electron
     launchLocalGame();
   };
+
+  useEffect(() => {
+    const listener = (msg: string) => {
+      alert(msg);
+    };
+    // Escuchamos errores al intentar lanzar el juego
+    window.ipc.receive('launch-local-error', listener);
+    return () => {
+      // eslint-disable-next-line @typescript-eslint/no-empty-function
+    };
+  }, []);
 
   return (
     <div className="main-container">


### PR DESCRIPTION
## Summary
- handle missing `LOCAL_GAME_SCRIPT` path in main IPC
- alert when the local launch fails on the start screen

## Testing
- `npm test --silent` *(fails: react-scripts not found)*

------
https://chatgpt.com/codex/tasks/task_e_68817ab111948325a845dc8b570e69cb